### PR TITLE
Add support for bitwise operators in expression parser

### DIFF
--- a/examples/expressions/expression_parser.go
+++ b/examples/expressions/expression_parser.go
@@ -42,15 +42,15 @@ func (b BinaryOp) Eval() int {
 	case "/":
 		return left / right
 	case "&":
-        return left & right
-    case "|":
-        return left | right
-    case "^":
-        return left ^ right
-    case "<<":
-        return left << right
-    case ">>":
-        return left >> right
+		return left & right
+	case "|":
+		return left | right
+	case "^":
+		return left ^ right
+	case "<<":
+		return left << right
+	case ">>":
+		return left >> right
 	default:
 		panic("Unknown operator: " + b.Op)
 	}
@@ -96,12 +96,12 @@ func parseOperator() parser.Parser[string] {
 	multiply := parser.StringParser("multiply", "*")
 	divide := parser.StringParser("divide", "/")
 	and := parser.StringParser("bitwise and", "&")
-    or := parser.StringParser("bitwise or", "|")
-    xor := parser.StringParser("bitwise xor", "^")
-    lshift := parser.StringParser("bitwise lshift", "<<")
-    rshift := parser.StringParser("bitwise rshift", ">>")
+	or := parser.StringParser("bitwise or", "|")
+	xor := parser.StringParser("bitwise xor", "^")
+	lshift := parser.StringParser("bitwise lshift", "<<")
+	rshift := parser.StringParser("bitwise rshift", ">>")
 
-    return parser.Or("operator", plus, minus, multiply, divide, lshift, rshift, and, or, xor)
+	return parser.Or("operator", plus, minus, multiply, divide, lshift, rshift, and, or, xor)
 }
 
 // Forward declaration for recursive parsing
@@ -270,12 +270,12 @@ func main() {
 		"10 + 2 * 3 - 4",    // Should be 12 (2*3=6, 10+6=16, 16-4=12)
 		"(1 + 2) * (3 + 4)", // Should be 21 (1+2=3, 3+4=7, 3*7=21)
 		"5 & 3",             // Should be 1
-        "5 | 2",             // Should be 7
-        "5 ^ 1",             // Should be 4
-        "8 << 2",            // Should be 32
-        "8 >> 1",            // Should be 4
-        "2 + 3 & 1",         // Should be 1 (2+3=5, 5&1=1)
-        "(2 + 3) << 2",      // Should be 20 ((2+3)=5, 5<<2=20)
+		"5 | 2",             // Should be 7
+		"5 ^ 1",             // Should be 4
+		"8 << 2",            // Should be 32
+		"8 >> 1",            // Should be 4
+		"2 + 3 & 1",         // Should be 1 (2+3=5, 5&1=1)
+		"(2 + 3) << 2",      // Should be 20 ((2+3)=5, 5<<2=20)
 	}
 
 	parser := parseArithmeticExpression()


### PR DESCRIPTION
This pull request enhances the expression parser in `examples/expressions/expression_parser.go` by adding support for bitwise operators (`&`, `|`, `^`, `<<`, `>>`). The changes include updates to the evaluation logic, operator parsing, and test cases to ensure proper functionality.
Added test expressions to validate the correct evaluation of bitwise operations and their precedence in combination with arithmetic operators. Examples include `5 & 3`, `8 << 2`, and `(2 + 3) << 2`.
<img width="747" height="531" alt="image" src="https://github.com/user-attachments/assets/01db32ac-d57f-43c3-8190-8741d69b5f89" />